### PR TITLE
apagar nbsp's, adicionar action e .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true

--- a/.github/workflows/fix-nbsp.yml
+++ b/.github/workflows/fix-nbsp.yml
@@ -25,6 +25,6 @@ jobs:
     - name: Remover NBSPs
       run: |
         nix run .#remove-nbsp
-    - name: Commitar lock
+    - name: Commitar alterações
       run: |
         git commit . -m "fix: remover NBSPs" && git push || echo "Nada para commitar"

--- a/.github/workflows/fix-nbsp.yml
+++ b/.github/workflows/fix-nbsp.yml
@@ -1,0 +1,30 @@
+name: "Buscar e remover Non-breaking Spaces"
+on:
+  pull_request:
+  push:
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Autenticar bot
+      uses: tibdex/github-app-token@v1
+      id: generate-token
+      with:
+        app_id: 251209
+        private_key: ${{ secrets.GELOS_BOT_KEY }}
+    - name: Configurar git
+      run: |
+        git config --global user.name "gelos-bot"
+        git config --global user.email "gelos-bot[bot]@users.noreply.github.com"
+    - name: Baixar repositório
+      uses: actions/checkout@v3
+      with:
+        token: ${{ steps.generate-token.outputs.token }}
+    - name: Instalar nix
+      uses: cachix/install-nix-action@v18
+    - name: Remover NBSPs
+      run: |
+        nix run .#remove-nbsp
+    - name: Commitar lock
+      run: |
+        git commit . -m "fix: remover NBSPs" && git push || echo "Nada para commitar"

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,9 @@
         echo "Serving on http://localhost:8000"
         ${pkgs.webfs}/bin/webfsd -F -f index.html -r ${gelos-site}/public
       '';
+      remove-nbsp = pkgs.writeShellScriptBin "remove-nbsp" ''
+        ${pkgs.gnused}/bin/sed 's/\xC2\xA0/ /g' -i $(find . -name '*.md')
+      '';
       default = gelos-site;
     };
 

--- a/src/_reports/2022-07-13-ata.md
+++ b/src/_reports/2022-07-13-ata.md
@@ -2,10 +2,10 @@
 title: Ata - Reunião 13/07/2022
 author: Deandreson
 attendees:
-    - Trents
-    - Deandreson
-    - Silmar
-    - Guilherme
+    - Trents
+    - Deandreson
+    - Silmar
+    - Guilherme
 ---
 
 Ata da reunião do Gelos dia 13/07/2022

--- a/src/_reports/2022-10-25-ata.md
+++ b/src/_reports/2022-10-25-ata.md
@@ -13,37 +13,36 @@ Ata - Reunião Geral CCOS/GELOS (Via jitsi) 25/10/2022
 ## Discussão
 
 - Site do CAASO (Centro Acadêmico Armando Salles Oliveira)
-    - Hospedar a página do caaso.org.br/
-    - Sobre a implementação de um servidor de e-mail, fácil de fazer mas difícil em manter
-    - Aproveitar a latência da internet na USP ao hospedar no servidor do Gelos
-    - Possibilidade do CAASO comprar e fornecer equipamentos ao Gelos ex: memória
-    - Usar a tecnologia livre e trazer mais transparência ao CAASO
-    - Criar uma instância do NextCloud para o CAASO
-    - E-mail devido às possíveis dificuldade em manter, sugerir uma empresa de servidor de e-mail mais em conta
-    - Visibilidade para o Gelos
-    
+    - Hospedar a página do caaso.org.br/
+    - Sobre a implementação de um servidor de e-mail, fácil de fazer mas difícil em manter
+    - Aproveitar a latência da internet na USP ao hospedar no servidor do Gelos
+    - Possibilidade do CAASO comprar e fornecer equipamentos ao Gelos ex: memória
+    - Usar a tecnologia livre e trazer mais transparência ao CAASO
+    - Criar uma instância do NextCloud para o CAASO
+    - E-mail devido às possíveis dificuldade em manter, sugerir uma empresa de servidor de e-mail mais em conta
+    - Visibilidade para o Gelos
+
 - Gerenciador de Livro e Visualizador:
-    - Verificar o Archive
-    - Analisar o Kavita
-    
+    - Verificar o Archive
+    - Analisar o Kavita
+
 - Mini Open-Source Show:
-    - Charles irá se apresentar sugeriu entre um dia entre dia 31/10-02/10
+    - Charles irá se apresentar sugeriu entre um dia entre dia 31/10-02/10
 - Relatório do Gelos
-    - Adicionar o Guilherme e finalizar o relatório com as atividades do ano
+    - Adicionar o Guilherme e finalizar o relatório com as atividades do ano
 - Atividades do Grupo:
-    - Rever as atividades planejadas para 2022, e finalizá-las
-    - Começar o planejamento para 2023
+    - Rever as atividades planejadas para 2022, e finalizá-las
+    - Começar o planejamento para 2023
 - Última atividades do grupo em 2022
-    - Convidar o professor Aroca para se apresentar e finalizar as atividades oficiais de 2022
-    - Fazer o convite oficial
-    
+    - Convidar o professor Aroca para se apresentar e finalizar as atividades oficiais de 2022
+    - Fazer o convite oficial
+
 - Convite para o Novo Gerente
-    - Fazer o convite/reforçar a Maíra, pois contribuiria para uma nova perspectiva ao Grupo em 2023
-    - Fazer o convite ao Higor para ser responsável pelas redes sociais 
-    
+    - Fazer o convite/reforçar a Maíra, pois contribuiria para uma nova perspectiva ao Grupo em 2023
+    - Fazer o convite ao Higor para ser responsável pelas redes sociais
+
 - Crescimento do Grupo
-    - Discussões sobre a participação apenas dos coordenadores nas reuniões
-    - Incentivar a participação dos interessados no grupo nas reuniões e projetos
-    - Discussões para tornar a participação em uma das reuniões, um critério de reconhecimento de vínculo com o grupo para 2023 
-- Reunião do Gelos 26/10, iniciar às 18:00    
-  
+    - Discussões sobre a participação apenas dos coordenadores nas reuniões
+    - Incentivar a participação dos interessados no grupo nas reuniões e projetos
+    - Discussões para tornar a participação em uma das reuniões, um critério de reconhecimento de vínculo com o grupo para 2023
+- Reunião do Gelos 26/10, iniciar às 18:00

--- a/src/_reports/2023-03-06-ata.md
+++ b/src/_reports/2023-03-06-ata.md
@@ -2,17 +2,17 @@
 title: Ata - Reunião 06/03/2023
 author: Deandreson
 attendees:
-    - Deandreson
-    - Setembru/Arthur
-    - Gabriel Fontes
-    - Rodrigo IFSC
-    - Charles
-    - Júlio
-    - Guilherme Paixão
-    - Matheus Cerqueira
-    - Silmar Pereira
-    - Leonardo Amaral
-    - Luis (Vamo)
+    - Deandreson
+    - Setembru/Arthur
+    - Gabriel Fontes
+    - Rodrigo IFSC
+    - Charles
+    - Júlio
+    - Guilherme Paixão
+    - Matheus Cerqueira
+    - Silmar Pereira
+    - Leonardo Amaral
+    - Luis (Vamo)
 ---
 
 Ata da Reunião do Gelos do dia 06/03/2023, total de pessoas 11
@@ -47,32 +47,28 @@ Ata da Reunião do Gelos do dia 06/03/2023, total de pessoas 11
    - Criar um grupo de trabalho no Telegram para organizar o InstallFest
 
  - Comunicação
-   - Criar artes para divulgar o installFest (Até o dia 10/03 pelo Júlio) 
+   - Criar artes para divulgar o installFest (Até o dia 10/03 pelo Júlio)
    - Cadastrar eventos no site do ICMC, uma semana antes (Até o dia 13/03 pelo Júlio)
    - Postar divulgação no instagram/Panfletagem pelo Campus
 
  - Vaquinha
    - Criar uma vaquinha para arrecadar dinheiro para o CoffeBreak
- 
+
 ## Gelos
  - Camisas do Gelos
- 
+
    - Mapear alunos interessados nas camisas do Gelos
-   - Cobrar um valor a mais para o caixa 
+   - Cobrar um valor a mais para o caixa
  - Reunião do Grupo
- 
+
    - Criar um WhenMeet para a semana 13/03 até 17/03
    - Sugestão de fazer a reunião após a Feira de Oportunidades e colher feedback
 
-## Debates 
- - Outras formas de arrecadação para o grupo para ter caixa e mais liberdade 
+## Debates
+ - Outras formas de arrecadação para o grupo para ter caixa e mais liberdade
  - Criar um workshop para divulgar no dia do InstallFest sobre: Git, Latex, Editor de Texto ou Filosofia
    - Argumentação sobre o tipo do conteúdo inicial, já que o público são de ingressantes na faculdade e ter um tema mais iniciante
    - Argumentação para conteúdo mais técnico buscando captar também integrantes com esse perfil
    - Sugestão de evoluir o conteúdo dos assuntos ao passar do semestre
-   - Análises sobre o público alvo baseado no curso, Latex para o grupo  Matemáticas/Físicas. Git para a Computação/Engenharia
+   - Análises sobre o público alvo baseado no curso, Latex para o grupo  Matemáticas/Físicas. Git para a Computação/Engenharia
  - Ampliar o grupo, buscar perfis diversos e interessados ao tema
-
-
-
-

--- a/src/_reports/2023-03-06-ata.md
+++ b/src/_reports/2023-03-06-ata.md
@@ -2,17 +2,17 @@
 title: Ata - Reunião 06/03/2023
 author: Deandreson
 attendees:
-    - Deandreson
-    - Setembru/Arthur
-    - Gabriel Fontes
-    - Rodrigo IFSC
-    - Charles
-    - Júlio
-    - Guilherme Paixão
-    - Matheus Cerqueira
-    - Silmar Pereira
-    - Leonardo Amaral
-    - Luis (Vamo)
+    - Deandreson
+    - Setembru/Arthur
+    - Gabriel Fontes
+    - Rodrigo IFSC
+    - Charles
+    - Júlio
+    - Guilherme Paixão
+    - Matheus Cerqueira
+    - Silmar Pereira
+    - Leonardo Amaral
+    - Luis (Vamo)
 ---
 
 Ata da Reunião do Gelos do dia 06/03/2023, total de pessoas 11

--- a/src/_reports/2023-03-06-ata.md
+++ b/src/_reports/2023-03-06-ata.md
@@ -2,17 +2,17 @@
 title: Ata - Reunião 06/03/2023
 author: Deandreson
 attendees:
-    - Deandreson
-    - Setembru/Arthur
-    - Gabriel Fontes
-    - Rodrigo IFSC
-    - Charles
-    - Júlio
-    - Guilherme Paixão
-    - Matheus Cerqueira
-    - Silmar Pereira
-    - Leonardo Amaral
-    - Luis (Vamo)
+    - Deandreson
+    - Setembru/Arthur
+    - Gabriel Fontes
+    - Rodrigo IFSC
+    - Charles
+    - Júlio
+    - Guilherme Paixão
+    - Matheus Cerqueira
+    - Silmar Pereira
+    - Leonardo Amaral
+    - Luis (Vamo)
 ---
 
 Ata da Reunião do Gelos do dia 06/03/2023, total de pessoas 11


### PR DESCRIPTION
O editor do Deandreson aparentemente cria [NBSP](https://en.wikipedia.org/wiki/Non-breaking_space), que deixam de criar novos bullets no markdown e zoam os front matters.

Esse PR arruma os existentes, e cria uma action para retirar eles automaticamente a cada push.

Também coloquei uma `.editorconfig` pra ver se evitamos também trailing spaces.