### PR TITLE
não rodar workflow fix-nbsp em forks

### DIFF
--- a/.github/workflows/fix-nbsp.yml
+++ b/.github/workflows/fix-nbsp.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   fix:
     runs-on: ubuntu-latest
+    # Não rodar em forks, já que forks não tem acesso a secrets.
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
     - name: Autenticar bot
       uses: tibdex/github-app-token@v1


### PR DESCRIPTION
A workflow que corrige NBSP não consegue rodar em forks, pois depende do secret do nosso bot para dar push aqui. Então vamos skippar ela caso o trigger seja de um fork.