### PR TITLE
corrigir excerpts arbitráriamente grande

### DIFF
--- a/src/_includes/listagem.html
+++ b/src/_includes/listagem.html
@@ -17,5 +17,5 @@
       {% endif %}
     </p>
   </header>
-  <div class="excerpt">{{ post.excerpt }}</div>
+  <div class="excerpt">{{ post.excerpt | truncatewords: 30 | strip_html }}</div>
 </article>


### PR DESCRIPTION
Os excerpts pegam o primeiro parágrafo, o problema é que se só tiver uma lista (o formato que eu uso qd faço ata), o excerpt é a lista toda!

Pra resolver isso, basta limitar o número de palavras. Temos que também strippar o HTML, se não as tags não são fechadas e zoa o resto da página.

Closes #39
