### PR TITLE
rework navegação

### DIFF
--- a/src/_data/external.yml
+++ b/src/_data/external.yml
@@ -4,12 +4,12 @@
 - name: Matrix
   url: https://matrix.to/#/#gelos:matrix.org
 
-- name: GitHub
-  url: https://github.com/gelos-icmc
-
 - name: Mastodon
   url: https://floss.social/@gelos
   rel: me # Verificação
+
+- name: GitHub
+  url: https://github.com/gelos-icmc
 
 - name: Instagram
   url: https://instagram.com/gelos.icmc/

--- a/src/_data/external.yml
+++ b/src/_data/external.yml
@@ -13,9 +13,3 @@
 
 - name: Instagram
   url: https://instagram.com/gelos.icmc/
-
-- name: Youtube
-  url: https://youtube.com/@gelos3943
-
-- name: Nextcloud
-  url: https://cloud.gelos.club

--- a/src/_data/navigation.yml
+++ b/src/_data/navigation.yml
@@ -8,5 +8,3 @@
   url: /reunioes/
 - name: Membros
   url: /membros/
-- name: Comunidades
-  url: /comunidades/

--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -29,11 +29,3 @@
     13566-590, São Carlos - SP
   </p>
 </address>
-
-<nav class="external">
-  <ul>
-    {% for item in site.data.external %}
-    <li><a href="{{ item.url }}" target="_blank" rel="noreferrer noopener {{ item.rel }}">{{ item.name }}</a></li>
-    {% endfor %}
-  </ul>
-</nav>

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -5,6 +5,7 @@
     <p><a href="https://icmc.usp.br/">ICMC</a>/<a href="https://usp.br/">USP</a></p>
   {% endif %}
 </div>
+
 <nav class="navigation">
   <ul>
     {% for item in site.data.navigation %}
@@ -13,6 +14,14 @@
         {{ item.name }}
       </a>
     </li>
+    {% endfor %}
+  </ul>
+</nav>
+
+<nav class="external">
+  <ul>
+    {% for item in site.data.external %}
+    <li><a href="{{ item.url }}" target="_blank" rel="noreferrer noopener {{ item.rel }}">{{ item.name }}</a></li>
     {% endfor %}
   </ul>
 </nav>

--- a/src/_sass/_main.scss
+++ b/src/_sass/_main.scss
@@ -37,7 +37,7 @@ a {
 // Lista de páginas na navegação
 nav ul {
   padding-left: 0;
-  margin-bottom: 2.5rem;
+  margin-bottom: 0.5em;
   // Tira bolinhas
   list-style: none;
 
@@ -98,6 +98,7 @@ figure {
 
   nav {
     max-width: 15em;
+    margin-bottom: 1em;
   }
 
   footer {
@@ -160,9 +161,17 @@ header > blockquote ul {
   }
 }
 
+body > header {
+  margin-bottom: 2em;
+}
+
+nav.external {
+  font-size: 0.9em;
+}
+
 footer {
   margin-top: 5em;
-  font-size: 85%;
+  font-size: 0.85em;
   border-top: 1px solid var(--color-blossom);
   address, nav {
     padding-top: 1em;
@@ -178,7 +187,7 @@ table {
 }
 
 main {
-  border-top: 1px solid var(--color-bg-alt);
+  border-top: 1px solid var(--color-blossom);
 }
 
 main > article > header {

--- a/src/sobre.md
+++ b/src/sobre.md
@@ -11,6 +11,10 @@ Computação](https://icmc.usp.br) da [Universidade de São
 Paulo](https://usp.br). O grupo é vinculado e conta com o apoio do [Centro de
 Competência em Open Source (CCOS)](https://ccos.icmc.usp.br/).
 
+Estamos sempre buscando nos aproximar de outras comunidades de software livre.
+Mantemos uma [lista](https://gelos.club/comunidades) das comunidades que
+conhecemos.
+
 Alguns dos nossos objetivos:
 - Fazer uma ponte entre a USP e a comunidade FLOSS;
 - Utilizar de recursos da USP para contribuir com software livre;


### PR DESCRIPTION
Esse PR mexe na nossa navegação, especialmente os links sociais/externos.

O propósito é tornar nossos links sociais movendo eles para o topo. Para que isso seja viável, retirei alguns elementos das navegaçoes; veja os commits individuais pra mais info.
