### PR TITLE
Adiciona meta de fediverse:creator

### DIFF
--- a/src/_layouts/root.html
+++ b/src/_layouts/root.html
@@ -22,6 +22,13 @@
     <link rel="icon" href="{% link assets/favicon.svg %}"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
+
+    {% if page.fediversecreator %}
+    <meta name="fediverse:creator" content="@{{ page.fediversecreator }}">
+    {% else %}
+    <meta name="fediverse:creator" content="@GELOS@floss.social">
+    {% endif %}
+    
     {% if page.is_post %}
     <meta property="og:type" content="article"/>
     {% else %}

--- a/src/_members/luana.mkdn
+++ b/src/_members/luana.mkdn
@@ -6,6 +6,7 @@ links:
     Site: luana.dev.br
     Mastodon: tech.lgbt/@luana
     GitHub: github.com/LuNeder
+fediversecreator: luana@tech.lgbt
 nusp: 13836963
 extra_css: |
     :root {


### PR DESCRIPTION
[Adicionado](https://github.com/mastodon/mastodon/pull/32383) no [Mastodon 4.3.1](https://github.com/mastodon/mastodon/releases/tag/v4.3.1) e provavelmente já está/já vai chegar em outros softwares do fediverso (interessante trackear: https://github.com/swicg/activitypub-html-discovery/issues/16)

O floss.social já atualizou pra 4.3.1, já fiz a configuração mastodon-side.